### PR TITLE
feat: 添加每月单独分支空提交保活

### DIFF
--- a/.github/workflows/empty-commit-keepalive.yml
+++ b/.github/workflows/empty-commit-keepalive.yml
@@ -1,0 +1,40 @@
+name: 单独分支空提交保活
+
+on:
+  schedule:
+    - cron: "0 9 1 * *" # 每月 1 日
+  workflow_dispatch: {}   # 支持手动触发，方便测试
+
+permissions:
+  contents: write   # 需要写权限来 push
+
+env:
+  BRANCH_NAME: heartbeat   # 目标分支名，可修改
+
+jobs:
+  empty-commit-keepalive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Init empty repo
+        run: |
+          # 初始化一个全新的 git 仓库，不依赖 actions/checkout
+          git init .
+          # 设置提交作者为 GitHub Actions 官方 bot
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # 配置远端，使用 GitHub 自动注入的 GITHUB_TOKEN
+          git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
+
+      - name: Create orphan branch
+        run: |
+          # 创建孤儿分支，没有历史和文件
+          git checkout --orphan "${BRANCH_NAME}"
+          # 空白提交
+          git commit --allow-empty -m "chore(heartbeat): monthly empty commit $(date -u +%Y-%m-%d)"
+          # 确认分支名正确
+          git branch -M "${BRANCH_NAME}"
+
+      - name: Push (force overwrite)
+        run: |
+          # 强制推送，无需 checkout，workflow 最简单
+          git push -f origin "${BRANCH_NAME}"

--- a/.github/workflows/quark_signin.yml
+++ b/.github/workflows/quark_signin.yml
@@ -90,16 +90,6 @@ jobs:
           path: .last_success_date
           key: last-success-marker
 
-      - name: 空提交保持活跃
-        if: success() && github.event_name == 'schedule'
-        run: |
-          git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
-          git config --local user.name "${{ github.actor }}"
-          git remote set-url origin https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}
-          git pull --rebase --autostash
-          git commit --allow-empty -m "CHORE: 保持运行.."
-          git push
-
       - name: 清理旧的工作流记录
         uses: Mattraks/delete-workflow-runs@main
         if: always()


### PR DESCRIPTION
- 把保活提交移动到单独的分支，以保持主分支整洁可读
- 频率从一天两次改成一个月一次，因为要超过60天无活动 GitHub 才会禁用 Actions

详情见 #3 
